### PR TITLE
Output both bessely and besselj for large arguments

### DIFF
--- a/src/asymptotics.jl
+++ b/src/asymptotics.jl
@@ -1,3 +1,26 @@
+function besseljy_large_argument(v, x::T) where T
+    # gives both (besselj, bessely) for x > 1.6*v
+    α, αp = _α_αp_asymptotic(v, x)
+    b = SQ2OPI(T) / sqrt(αp * x)
+
+    # we need to calculate sin(x - v*pi/2 - pi/4) and cos(x - v*pi/2 - pi/4)
+    # For improved accuracy this is expanded using the formula for sin(x+y+z)
+
+    S, C = sincos(PIO2(T) * v)
+    Sα, Cα = sincos(α)
+
+    CMS = C - S
+    CPS = C + S
+
+    s1 = CMS * Cα
+    s2 = CPS * Sα
+
+    s3 = CMS * Sα
+    s4 = CPS * Cα
+
+    return SQ2O2(T) * (s1 + s2) * b, SQ2O2(T) * (s3 - s4) * b
+end
+
 function _α_αp_asymptotic(v, x::Float64)
     if x > 5*v
         return _α_αp_poly_10(v, x)

--- a/src/besselj.jl
+++ b/src/besselj.jl
@@ -163,7 +163,7 @@ function _besselj(nu, x)
     x < 4.0 && return besselj_small_arguments_orders(nu, x)
 
     large_arg_cutoff = 1.65*nu
-    (x > large_arg_cutoff && x > 20.0) && return besselj_large_argument(nu, x)
+    (x > large_arg_cutoff && x > 20.0) && return besseljy_large_argument(nu, x)[1]
 
 
     debye_cutoff = 2.0 + 1.00035*x + (302.681*x)^(1/3)
@@ -190,8 +190,8 @@ function _besselj(nu, x)
     if (debye_diff > large_arg_diff && x > 20.0)
         nu_shift = ceil(large_arg_diff)
         v2 = nu - nu_shift
-        jnu = besselj_large_argument(v2, x)
-        jnum1 = besselj_large_argument(v2 - 1, x)
+        jnu = besseljy_large_argument(v2, x)[1]
+        jnum1 = besseljy_large_argument(v2 - 1, x)[1]
         return besselj_up_recurrence(x, jnu, jnum1, v2, nu)[2]
     else
         nu_shift = ceil(Int, debye_diff)
@@ -201,20 +201,6 @@ function _besselj(nu, x)
         jnup1 = besselj_debye(v+1, x)
         return besselj_down_recurrence(x, jnu, jnup1, arr)[2]
     end
-end
-
-# for moderate size arguments of x and v this has relative errors ~9e-15
-# for large arguments relative errors ~1e-13
-function besselj_large_argument(v, x::T) where T
-    α, αp = _α_αp_asymptotic(v, x)
-    b = SQ2OPI(T) / sqrt(αp * x)
-
-    S, C = sincos(PIO2(T)*v)
-    Sα, Cα = sincos(α)
-    s1 = (C - S) * Cα
-    s2 = (C + S) * Sα
-
-    return SQ2O2(T) * (s1 + s2) * b
 end
 
 # generally can only use for x < 4.0

--- a/test/bessely_test.jl
+++ b/test/bessely_test.jl
@@ -64,3 +64,7 @@ y1_32 = bessely1.(Float32.(x))
 # test that Inf inputs go to zero
 @test bessely1(Inf32) == zero(Float32)
 @test bessely1(Inf64) == zero(Float64)
+
+
+# briefly test the large argument is working
+@test Bessels.besseljy_large_argument(10.0, 100.0)[2] ≈ SpecialFunctions.bessely(10.0, 100.0)


### PR DESCRIPTION
This modifies the asymptotic expansion to export both `bessely` and `besselj` for large arguments. This allows for computation of both `bessely` and `besselj` in about the same time.

Computing just `besselj` on master.

```julia
julia> @benchmark Bessels.besselj_large_argument(10.0, x) setup=(x=100.0+rand())

BenchmarkTools.Trial: 10000 samples with 986 evaluations.
 Range (min … max):  51.470 ns … 87.352 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     51.637 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   52.009 ns ±  2.329 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ██▅       ▃▂▁                                               ▂
  ███▁▄▄▁▁▃▆███▆▆▅▄▄▅▆▇▆▅▇▅▄▃▅▅▅▄▄▃▄▄▃▅▃▃▅▄▁▃▄▃▃▁▃▃▁▁▃▄▄▃▅▄▁▄ █
  51.5 ns      Histogram: log(frequency) by time        61 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

and computing both `besselj` and `bessely` on this PR
```julia
julia> @benchmark Bessels.besseljy_large_argument(10.0, x) setup=(x=100.0+rand())
BenchmarkTools.Trial: 10000 samples with 985 evaluations.
 Range (min … max):  54.583 ns … 85.532 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     54.871 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   55.354 ns ±  2.262 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅█▆▃     ▂▂                                                 ▁
  ████▄▄▁▄▇███▇▆▆▆▇▇▇▆▆▇▆▆▆▅▆▆▄▅▅▃▄▃▃▆▅▃▅▄▅▆▅▇█▁▅▅▃▅▃▅▄▄▅▄▅▃▄ █
  54.6 ns      Histogram: log(frequency) by time      66.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

(I'm going to try to keep these PRs smaller)